### PR TITLE
 admin: image uploads, gallery UX overhaul, portfolio client-side nav…

### DIFF
--- a/tattooista-next/.gitignore
+++ b/tattooista-next/.gitignore
@@ -2,6 +2,9 @@
 
 # dependencies
 /node_modules
+
+# local uploads
+/public/uploads
 /.pnp
 .pnp.*
 .yarn/*

--- a/tattooista-next/prisma/schema.prisma
+++ b/tattooista-next/prisma/schema.prisma
@@ -43,6 +43,18 @@ model Studio {
   stripeSubscriptionId String?
   isActive             Boolean  @default(true)
 
+  // Hero block
+  heroImage            String?  // background image for hero section
+  heroPortrait         String?  // portrait/illustration overlay on hero
+  heroTextLeft         String?  // rotated label (e.g. "Tattoo Artist")
+  heroTextCenter       String?  // main heading (two lines separated by \n)
+  heroTextBottom       String?  // tagline below heading
+
+  // Contact & social
+  phone                String?
+  instagram            String?
+  facebook             String?
+
   memberships StudioMembership[]
   clients     Client[]
   contacts    Contact[]

--- a/tattooista-next/prisma/seed.ts
+++ b/tattooista-next/prisma/seed.ts
@@ -33,10 +33,27 @@ async function main() {
   // Create demo studio
   const demoStudio = await prisma.studio.upsert({
     where: { slug: "demo" },
-    update: {},
+    update: {
+      heroImage: "/images/body-bg.jpg",
+      heroPortrait: "/images/offerIllustration.png",
+      heroTextLeft: "Tattoo Artist",
+      heroTextCenter: "Your\nStudio",
+      heroTextBottom: "Your tagline goes here",
+      phone: "+1234567890",
+      instagram: "#",
+      facebook: "#",
+    },
     create: {
       name: "Demo Tattoo Studio",
       slug: "demo",
+      heroImage: "/images/body-bg.jpg",
+      heroPortrait: "/images/offerIllustration.png",
+      heroTextLeft: "Tattoo Artist",
+      heroTextCenter: "Your\nStudio",
+      heroTextBottom: "Your tagline goes here",
+      phone: "+1234567890",
+      instagram: "#",
+      facebook: "#",
     },
   })
 

--- a/tattooista-next/src/app/[slug]/(public)/layout.tsx
+++ b/tattooista-next/src/app/[slug]/(public)/layout.tsx
@@ -13,10 +13,12 @@ export default async function StudioPublicLayout({
 }) {
   const { slug } = await params
 
-  // Validate the studio exists and is active
   const studio = await prisma.studio.findUnique({
     where: { slug },
-    select: { id: true, isActive: true, slug: true },
+    select: {
+      id: true, isActive: true, slug: true,
+      phone: true, instagram: true, facebook: true, logo: true,
+    },
   })
 
   if (!studio || !studio.isActive) {
@@ -25,7 +27,13 @@ export default async function StudioPublicLayout({
 
   return (
     <>
-      <Header studioSlug={slug} />
+      <Header
+        studioSlug={slug}
+        logo={studio.logo}
+        phone={studio.phone}
+        instagram={studio.instagram}
+        facebook={studio.facebook}
+      />
       <main>{children}</main>
       <Contacts />
       <Footer />

--- a/tattooista-next/src/app/[slug]/(public)/page.tsx
+++ b/tattooista-next/src/app/[slug]/(public)/page.tsx
@@ -12,7 +12,11 @@ import { pageWallpaperUrl, serviceWallpaperUrl } from "@/lib/image-utils"
 async function getHomePageData(slug: string) {
   const studio = await prisma.studio.findUnique({
     where: { slug },
-    select: { id: true, isActive: true },
+    select: {
+      id: true, isActive: true,
+      heroImage: true, heroPortrait: true, heroTextLeft: true, heroTextCenter: true, heroTextBottom: true,
+      phone: true, instagram: true, facebook: true,
+    },
   })
 
   if (!studio || !studio.isActive) return null
@@ -36,7 +40,7 @@ async function getHomePageData(slug: string) {
     }),
   ])
 
-  return { services, faqItems, aboutPage, tattooStyles }
+  return { studio, services, faqItems, aboutPage, tattooStyles }
 }
 
 export default async function StudioHomePage({
@@ -51,13 +55,17 @@ export default async function StudioHomePage({
     notFound()
   }
 
-  const { services, faqItems, aboutPage, tattooStyles } = data
+  const { studio, services, faqItems, aboutPage, tattooStyles } = data
+  const heroLines = (studio.heroTextCenter || "Your\nName").split("\n")
 
   return (
     <div>
       {/* Hero / Main Offer */}
       <section
-        className="relative flex flex-col items-start h-[432px] md:h-screen pt-[107px] px-4 md:pt-[270px] md:px-[70px] md:pb-[93px] overflow-visible bg-no-repeat bg-[length:360px_337px,cover] md:bg-[length:contain,cover] bg-[position:top_95px_right_-25px,center] md:bg-[position:bottom_0_right_0,top_center] bg-[url('/images/offerIllustration.png'),url('/images/body-bg.jpg')]"
+        className="relative flex flex-col items-start h-[432px] md:h-screen pt-[107px] px-4 md:pt-[270px] md:px-[70px] md:pb-[93px] overflow-visible bg-no-repeat bg-[length:360px_337px,cover] md:bg-[length:contain,cover] bg-[position:top_95px_right_-25px,center] md:bg-[position:bottom_0_right_0,top_center]"
+        style={{
+          backgroundImage: `url('${studio.heroPortrait || "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"}'), url('${studio.heroImage || "/images/body-bg.jpg"}')`,
+        }}
       >
         {/* Bottom gradient overlay */}
         <div className="absolute bottom-0 left-0 right-0 h-[111px] md:h-[187px] bg-gradient-to-t from-[#080808] to-transparent" />
@@ -66,16 +74,17 @@ export default async function StudioHomePage({
         <div className="relative pl-[28px] md:pl-[66px] uppercase leading-none">
           {/* Decorative rotated text */}
           <span className="absolute -left-[40px] top-[42px] md:-left-[68px] md:top-[74px] text-[10px] md:text-[18px] font-medium md:font-semibold text-[#c7c7c7] tracking-[1.5px] -rotate-90 before:content-[''] before:absolute before:w-[21px] md:before:w-[45px] before:h-[2px] before:bg-[#c7c7c7] before:top-1/2 before:-left-[5px] md:before:-left-[10px] before:-translate-x-full before:-translate-y-1/2">
-            Tattoo Artist
+            {studio.heroTextLeft || "Tattoo Artist"}
           </span>
 
           <h1 className="flex flex-col text-left text-[46px] md:text-[130px] font-bold leading-[0.9] m-0 [text-shadow:2px_2px_3px_rgba(0,0,0,0.8)]">
-            <span>Hobf</span>
-            <span>Adelaine</span>
+            {heroLines.map((line, i) => (
+              <span key={i}>{line}</span>
+            ))}
           </h1>
 
           <span className="block py-[22px] md:py-0 md:mt-[14px] w-[140px] md:w-auto text-[13px] md:text-[30px] font-normal text-[#c7c7c7] leading-[15.85px] md:leading-normal tracking-[0.6px] md:tracking-[1px] md:text-right">
-            Your philosophy on your skin
+            {studio.heroTextBottom || ""}
           </span>
         </div>
 
@@ -94,7 +103,7 @@ export default async function StudioHomePage({
           <h2 className="text-center text-[30px] md:text-[55px] font-bold uppercase tracking-wider mb-10 md:mb-[100px]">
             Portfolio
           </h2>
-          <PortfolioSlider styles={tattooStyles} />
+          <PortfolioSlider styles={tattooStyles} slug={slug} />
         </section>
       )}
 
@@ -125,24 +134,30 @@ export default async function StudioHomePage({
                 </div>
               )}
               <div className="mt-[40px]">
+                {(studio.instagram || studio.facebook) && (
                 <h3 className="text-left text-[25px] md:text-[43px] font-semibold mb-5">Follow me</h3>
+                )}
                 <nav className="flex gap-5 mb-[40px]">
+                  {studio.instagram && (
                   <a
-                    href="https://www.instagram.com/adelainehobf/"
+                    href={studio.instagram}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-foreground hover:text-foreground/70 transition-colors"
                   >
                     <Instagram className="w-[70px] h-[70px]" />
                   </a>
+                  )}
+                  {studio.facebook && (
                   <a
-                    href="https://www.facebook.com/a.hobf"
+                    href={studio.facebook}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-foreground hover:text-foreground/70 transition-colors"
                   >
                     <Facebook className="w-[70px] h-[70px]" />
                   </a>
+                  )}
                 </nav>
                 <a
                   href="#booking"

--- a/tattooista-next/src/app/[slug]/(public)/portfolio/page.tsx
+++ b/tattooista-next/src/app/[slug]/(public)/portfolio/page.tsx
@@ -1,10 +1,9 @@
 export const dynamic = "force-dynamic"
 
 import { Metadata } from "next"
+import { notFound } from "next/navigation"
 import { prisma } from "@/lib/prisma"
-import { Advertisement } from "@/components/shared/advertisement"
-import { StyleSlider } from "@/components/shared/style-slider"
-import { GalleryInfinite } from "@/components/shared/gallery-infinite"
+import { PortfolioContent } from "./portfolio-content"
 
 export const metadata: Metadata = {
   title: "Portfolio",
@@ -12,21 +11,31 @@ export const metadata: Metadata = {
 }
 
 interface PortfolioPageProps {
+  params: Promise<{ slug: string }>
   searchParams: Promise<{ style?: string }>
 }
 
-async function getPortfolioData(styleId?: string) {
+async function getPortfolioData(slug: string, requestedStyleId?: string) {
+  const studio = await prisma.studio.findUnique({
+    where: { slug },
+    select: { id: true, isActive: true },
+  })
+
+  if (!studio || !studio.isActive) return null
+
   const styles = await prisma.tattooStyle.findMany({
-    where: { isArchived: false },
+    where: { studioId: studio.id, isArchived: false },
     orderBy: { value: "asc" },
   })
 
-  const activeStyleId = styleId || styles[0]?.id || null
-  const activeStyle = styles.find((s) => s.id === activeStyleId) || null
-
+  const activeStyleId =
+    (requestedStyleId && styles.some((s) => s.id === requestedStyleId)
+      ? requestedStyleId
+      : null) || styles[0]?.id || null
   const pageSize = 20
 
   const where = {
+    studioId: studio.id,
     isArchived: false,
     ...(activeStyleId && {
       styles: {
@@ -46,56 +55,33 @@ async function getPortfolioData(styleId?: string) {
     prisma.galleryItem.count({ where }),
   ])
 
-  return { styles, activeStyle, galleryItems, totalCount, pageSize }
+  return { styles, galleryItems, totalCount, pageSize, activeStyleId }
 }
 
-export default async function PortfolioPage({ searchParams }: PortfolioPageProps) {
-  const params = await searchParams
-  const { styles, activeStyle, galleryItems, totalCount, pageSize } =
-    await getPortfolioData(params.style)
+export default async function PortfolioPage({ params, searchParams }: PortfolioPageProps) {
+  const { slug } = await params
+  const { style } = await searchParams
+  const data = await getPortfolioData(slug, style)
+
+  if (!data) notFound()
+
+  const { styles, galleryItems, totalCount, pageSize, activeStyleId } = data
 
   return (
-    <>
-      {/* Styles Section */}
-      <section className="tattoo-style-section relative pt-[118px] md:pt-[220px] md:pb-[28px] md:mb-0 bg-[url('/images/body-bg.jpg')] bg-no-repeat bg-cover">
-        <div className="container overflow-visible">
-          {/* Style title + description */}
-          <div className="flex flex-col leading-[1.4] md:flex-row md:gap-[60px] md:mx-auto md:max-w-[1317px]">
-            <div>
-              <h1 className="relative mt-0 mb-4 md:mb-6 max-w-full overflow-hidden text-ellipsis text-[36px] md:text-[80px] text-center font-bold uppercase tracking-wider">
-                {activeStyle?.value || "Portfolio"}
-              </h1>
-              <div className="text-center">
-                {activeStyle?.description || "---"}
-              </div>
-            </div>
-          </div>
-
-          <Advertisement />
-
-          <StyleSlider
-            styles={styles.map((s) => ({
-              id: s.id,
-              value: s.value,
-              nonStyle: s.nonStyle,
-            }))}
-            activeStyleId={activeStyle?.id || null}
-          />
-        </div>
-      </section>
-
-      {/* Gallery Section */}
-      {activeStyle && (
-        <GalleryInfinite
-          styleId={activeStyle.id}
-          initialItems={galleryItems.map((item) => ({
-            id: item.id,
-            fileName: item.fileName,
-          }))}
-          initialTotalCount={totalCount}
-          pageSize={pageSize}
-        />
-      )}
-    </>
+    <PortfolioContent
+      styles={styles.map((s) => ({
+        id: s.id,
+        value: s.value,
+        description: s.description,
+        nonStyle: s.nonStyle,
+      }))}
+      initialStyleId={activeStyleId}
+      initialGalleryItems={galleryItems.map((item) => ({
+        id: item.id,
+        fileName: item.fileName,
+      }))}
+      initialTotalCount={totalCount}
+      pageSize={pageSize}
+    />
   )
 }

--- a/tattooista-next/src/app/[slug]/(public)/portfolio/portfolio-content.tsx
+++ b/tattooista-next/src/app/[slug]/(public)/portfolio/portfolio-content.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { Advertisement } from "@/components/shared/advertisement"
+import { StyleSlider } from "@/components/shared/style-slider"
+import { GalleryInfinite } from "@/components/shared/gallery-infinite"
+
+type StyleData = {
+  id: string
+  value: string
+  description: string | null
+  nonStyle: boolean
+}
+
+type GalleryItem = {
+  id: string
+  fileName: string
+}
+
+type Props = {
+  styles: StyleData[]
+  initialStyleId: string | null
+  initialGalleryItems: GalleryItem[]
+  initialTotalCount: number
+  pageSize: number
+}
+
+export function PortfolioContent({
+  styles,
+  initialStyleId,
+  initialGalleryItems,
+  initialTotalCount,
+  pageSize,
+}: Props) {
+  const [activeStyleId, setActiveStyleId] = useState<string | null>(initialStyleId)
+  const [galleryItems, setGalleryItems] = useState<GalleryItem[]>(initialGalleryItems)
+  const [totalCount, setTotalCount] = useState(initialTotalCount)
+  const [isLoadingStyle, setIsLoadingStyle] = useState(false)
+
+  const activeStyle = styles.find((s) => s.id === activeStyleId) || null
+
+  const handleStyleSelect = useCallback(async (styleId: string) => {
+    if (styleId === activeStyleId) return
+
+    setActiveStyleId(styleId)
+    setIsLoadingStyle(true)
+
+    try {
+      const res = await fetch(`/api/gallery?styleId=${styleId}&page=1&pageSize=${pageSize}`)
+      const data = await res.json()
+      setGalleryItems(data.gallery)
+      setTotalCount(data.totalCount)
+    } catch (err) {
+      console.error("Failed to fetch gallery:", err)
+    } finally {
+      setIsLoadingStyle(false)
+    }
+  }, [activeStyleId, pageSize])
+
+  return (
+    <>
+      {/* Styles Section */}
+      <section className="tattoo-style-section relative pt-[118px] md:pt-[220px] md:pb-[28px] md:mb-0 bg-[url('/images/body-bg.jpg')] bg-no-repeat bg-cover">
+        <div className="container overflow-visible">
+          <div className="flex flex-col leading-[1.4] md:flex-row md:gap-[60px] md:mx-auto md:max-w-[1317px]">
+            <div>
+              <h1 className="relative mt-0 mb-4 md:mb-6 max-w-full overflow-hidden text-ellipsis text-[36px] md:text-[80px] text-center font-bold uppercase tracking-wider">
+                {activeStyle?.value || "Portfolio"}
+              </h1>
+              <div className="text-center">
+                {activeStyle?.description || "---"}
+              </div>
+            </div>
+          </div>
+
+          <Advertisement />
+
+          <StyleSlider
+            styles={styles.map((s) => ({
+              id: s.id,
+              value: s.value,
+              nonStyle: s.nonStyle,
+            }))}
+            activeStyleId={activeStyleId}
+            onStyleSelect={handleStyleSelect}
+          />
+        </div>
+      </section>
+
+      {/* Gallery Section */}
+      {activeStyle && (
+        isLoadingStyle ? (
+          <section className="relative pt-[30px] md:pt-[60px] container">
+            <div className="flex justify-center py-8">
+              <div className="w-8 h-8 border-2 border-foreground border-t-transparent animate-spin" />
+            </div>
+          </section>
+        ) : (
+          <GalleryInfinite
+            key={activeStyleId}
+            styleId={activeStyle.id}
+            initialItems={galleryItems}
+            initialTotalCount={totalCount}
+            pageSize={pageSize}
+          />
+        )
+      )}
+    </>
+  )
+}

--- a/tattooista-next/src/app/[slug]/admin/gallery/gallery-manager.tsx
+++ b/tattooista-next/src/app/[slug]/admin/gallery/gallery-manager.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -20,7 +20,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Checkbox } from "@/components/ui/checkbox"
-import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
   createManyGalleryItems,
@@ -28,8 +27,9 @@ import {
   archiveGalleryItem,
   deleteGalleryItem,
 } from "@/lib/actions/gallery"
-import { Upload, MoreVertical, Archive, Trash2, Tag } from "lucide-react"
+import { Upload, MoreVertical, Archive, Trash2, Tag, X, ImagePlus } from "lucide-react"
 import { galleryImageUrl } from "@/lib/image-utils"
+import { LoadingSpinner } from "@/components/shared/loading-spinner"
 import type { TattooStyle } from "@prisma/client"
 
 interface GalleryItem {
@@ -45,21 +45,56 @@ interface GalleryManagerProps {
   styles: TattooStyle[]
 }
 
+interface FilePreview {
+  file: File
+  previewUrl: string
+}
+
 export function GalleryManager({ galleryItems, styles }: GalleryManagerProps) {
   const router = useRouter()
   const [isUploadDialogOpen, setIsUploadDialogOpen] = useState(false)
   const [selectedStyleIds, setSelectedStyleIds] = useState<string[]>([])
   const [editingItem, setEditingItem] = useState<GalleryItem | null>(null)
   const [isUploading, setIsUploading] = useState(false)
+  const [filePreviews, setFilePreviews] = useState<FilePreview[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files
-    if (!files || files.length === 0) return
+  const handleFilesSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || [])
+    if (files.length === 0) return
+
+    // Reset input so the same files can be re-selected if needed
+    if (fileInputRef.current) fileInputRef.current.value = ""
+
+    const totalFiles = files.length
+    const newPreviews: FilePreview[] = []
+    for (const file of files) {
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        newPreviews.push({ file, previewUrl: reader.result as string })
+        if (newPreviews.length === totalFiles) {
+          setFilePreviews((prev) => [...prev, ...newPreviews])
+        }
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  const handleRemovePreview = (fileToRemove: File) => {
+    setFilePreviews((prev) => prev.filter(({ file }) => file !== fileToRemove))
+  }
+
+  const handleUploadSubmit = async () => {
+    if (filePreviews.length === 0) return
+    if (selectedStyleIds.length === 0) {
+      toast.error("Please select at least one style")
+      return
+    }
 
     setIsUploading(true)
     try {
       const formData = new FormData()
-      for (const file of Array.from(files)) {
+      for (const { file } of filePreviews) {
         formData.append("files", file)
       }
       formData.append("context", "gallery")
@@ -85,12 +120,21 @@ export function GalleryManager({ galleryItems, styles }: GalleryManagerProps) {
         toast.success(`${data.files.length} image(s) uploaded successfully`)
         setIsUploadDialogOpen(false)
         setSelectedStyleIds([])
+        setFilePreviews([])
         router.refresh()
       }
     } catch {
       toast.error("Upload failed")
     } finally {
       setIsUploading(false)
+    }
+  }
+
+  const handleDialogClose = (open: boolean) => {
+    setIsUploadDialogOpen(open)
+    if (!open) {
+      setFilePreviews([])
+      setSelectedStyleIds([])
     }
   }
 
@@ -133,25 +177,68 @@ export function GalleryManager({ galleryItems, styles }: GalleryManagerProps) {
   return (
     <>
       <div className="flex justify-end mb-4">
-        <Dialog open={isUploadDialogOpen} onOpenChange={setIsUploadDialogOpen}>
+        <Dialog open={isUploadDialogOpen} onOpenChange={handleDialogClose}>
           <DialogTrigger asChild>
             <Button>
               <Upload className="mr-2 h-4 w-4" />
               Upload Images
             </Button>
           </DialogTrigger>
-          <DialogContent className="max-w-lg">
+          <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
             <DialogHeader>
               <DialogTitle>Upload Gallery Images</DialogTitle>
               <DialogDescription>
-                Upload images to your portfolio gallery.
+                Select images, choose styles, then upload.
               </DialogDescription>
             </DialogHeader>
+
+            {/* Image Previews */}
+            {filePreviews.length > 0 && (
+              <div className="space-y-2">
+                <Label>Selected images ({filePreviews.length}):</Label>
+                <div className="grid grid-cols-3 gap-2">
+                  {filePreviews.map(({ file, previewUrl }) => (
+                    <div key={file.name + file.lastModified} className="relative aspect-square rounded-lg overflow-hidden bg-muted">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={previewUrl}
+                        alt="Preview"
+                        className="w-full h-full object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => handleRemovePreview(file)}
+                        className="absolute top-1 right-1 p-1 rounded-full bg-black/60 text-white hover:bg-black/80 transition-colors"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Pick Files Button */}
+            <div>
+              <label className="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium cursor-pointer bg-muted hover:bg-muted/80 transition-colors">
+                <ImagePlus className="h-4 w-4" />
+                {filePreviews.length > 0 ? "Add More Images" : "Pick Files"}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  multiple
+                  className="hidden"
+                  onChange={handleFilesSelected}
+                  disabled={isUploading}
+                />
+              </label>
+            </div>
 
             {/* Style Selection */}
             {styles.length > 0 && (
               <div className="space-y-3">
-                <Label>Select styles for uploaded images:</Label>
+                <Label>Select styles for uploaded images: *</Label>
                 <div className="grid grid-cols-2 gap-2">
                   {styles
                     .filter((style) => !style.nonStyle)
@@ -182,18 +269,21 @@ export function GalleryManager({ galleryItems, styles }: GalleryManagerProps) {
               </div>
             )}
 
-            <div className="space-y-2">
-              <Input
-                type="file"
-                accept="image/*"
-                multiple
-                onChange={handleFileUpload}
-                disabled={isUploading}
-              />
-              {isUploading && (
-                <p className="text-sm text-muted-foreground text-center">Uploading...</p>
+            {/* Submit */}
+            <Button
+              onClick={handleUploadSubmit}
+              disabled={isUploading || filePreviews.length === 0 || selectedStyleIds.length === 0}
+              className="w-full"
+            >
+              {isUploading ? (
+                <>
+                  <LoadingSpinner size="sm" className="mr-2" />
+                  Uploading...
+                </>
+              ) : (
+                `Upload ${filePreviews.length} Image${filePreviews.length !== 1 ? "s" : ""}`
               )}
-            </div>
+            </Button>
           </DialogContent>
         </Dialog>
       </div>

--- a/tattooista-next/src/app/[slug]/admin/settings/delete-studio-button.tsx
+++ b/tattooista-next/src/app/[slug]/admin/settings/delete-studio-button.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { deleteStudio } from "@/lib/actions/studio"
+import { LoadingSpinner } from "@/components/shared/loading-spinner"
+
+export function DeleteStudioButton() {
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleDelete() {
+    setIsDeleting(true)
+    setError(null)
+    const result = await deleteStudio()
+    if (result.error) {
+      setError(result.error)
+      setIsDeleting(false)
+      return
+    }
+    window.location.href = "/"
+  }
+
+  return (
+    <div>
+      <AlertDialog>
+        <AlertDialogTrigger asChild>
+          <Button variant="destructive">Delete Studio</Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete your studio, all clients, bookings,
+              gallery items, styles, services, FAQ, and pages. This action
+              cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? (
+                <><LoadingSpinner size="sm" className="mr-2" />Deleting...</>
+              ) : "Yes, delete everything"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      {error && <p className="text-destructive text-sm mt-2">{error}</p>}
+    </div>
+  )
+}

--- a/tattooista-next/src/app/[slug]/admin/settings/page.tsx
+++ b/tattooista-next/src/app/[slug]/admin/settings/page.tsx
@@ -1,31 +1,51 @@
+export const dynamic = "force-dynamic"
+
 import { Metadata } from "next"
+import { redirect } from "next/navigation"
+import { getStudioSettings } from "@/lib/actions/studio"
+import { StudioSettingsForm } from "./studio-settings-form"
+import { DeleteStudioButton } from "./delete-studio-button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 
 export const metadata: Metadata = {
   title: "Settings",
 }
 
-export default function SettingsPage() {
+export default async function SettingsPage() {
+  const studio = await getStudioSettings()
+
+  if (!studio) {
+    redirect("/")
+  }
+
   return (
     <div className="space-y-6 max-w-2xl">
       <div>
         <h1 className="text-3xl font-bold">Settings</h1>
         <p className="text-muted-foreground">
-          Manage your application settings.
+          Manage your studio settings.
         </p>
       </div>
 
-      <Card>
+      <StudioSettingsForm studio={studio} />
+
+      <Card className="border-destructive">
         <CardHeader>
-          <CardTitle>General Settings</CardTitle>
+          <CardTitle className="text-destructive">Danger Zone</CardTitle>
           <CardDescription>
-            Configure general application settings.
+            Irreversible actions. Proceed with caution.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <p className="text-muted-foreground">
-            Settings page is under development. Check back soon!
-          </p>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium">Delete Studio</p>
+              <p className="text-sm text-muted-foreground">
+                Permanently delete this studio and all its data.
+              </p>
+            </div>
+            <DeleteStudioButton />
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/tattooista-next/src/app/[slug]/admin/settings/studio-settings-form.tsx
+++ b/tattooista-next/src/app/[slug]/admin/settings/studio-settings-form.tsx
@@ -1,0 +1,223 @@
+"use client"
+
+import { useRef, useState } from "react"
+import Image from "next/image"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { updateStudioSettings } from "@/lib/actions/studio"
+import { LoadingSpinner } from "@/components/shared/loading-spinner"
+import { toast } from "sonner"
+import { Upload, X } from "lucide-react"
+
+interface StudioSettings {
+  name: string
+  slug: string
+  logo: string | null
+  heroImage: string | null
+  heroPortrait: string | null
+  heroTextLeft: string | null
+  heroTextCenter: string | null
+  heroTextBottom: string | null
+  phone: string | null
+  instagram: string | null
+  facebook: string | null
+}
+
+function ImageUploadField({
+  label,
+  value,
+  onChange,
+  context,
+}: {
+  label: string
+  value: string
+  onChange: (url: string) => void
+  context: string
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [isUploading, setIsUploading] = useState(false)
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setIsUploading(true)
+    try {
+      const formData = new FormData()
+      formData.append("files", file)
+      formData.append("context", context)
+
+      const res = await fetch("/api/upload", { method: "POST", body: formData })
+      const data = await res.json()
+
+      if (!res.ok) {
+        toast.error(data.error || "Upload failed")
+        return
+      }
+
+      onChange(data.files[0].url)
+      toast.success("Image uploaded")
+    } catch {
+      toast.error("Upload failed")
+    } finally {
+      setIsUploading(false)
+      if (inputRef.current) inputRef.current.value = ""
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      {value && (
+        <div className="relative w-32 h-32 border rounded overflow-hidden group">
+          <Image src={value} alt={label} fill className="object-cover" />
+          <button
+            type="button"
+            onClick={() => onChange("")}
+            className="absolute top-1 right-1 bg-black/60 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+          >
+            <X className="h-3 w-3 text-white" />
+          </button>
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={isUploading}
+          onClick={() => inputRef.current?.click()}
+        >
+          {isUploading ? (
+            <><LoadingSpinner size="sm" className="mr-2" />Uploading...</>
+          ) : (
+            <><Upload className="h-4 w-4 mr-2" />Upload</>
+          )}
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+      </div>
+    </div>
+  )
+}
+
+export function StudioSettingsForm({ studio }: { studio: StudioSettings }) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [form, setForm] = useState({
+    name: studio.name,
+    logo: studio.logo ?? "",
+    heroImage: studio.heroImage ?? "",
+    heroPortrait: studio.heroPortrait ?? "",
+    heroTextLeft: studio.heroTextLeft ?? "",
+    heroTextCenter: studio.heroTextCenter ?? "",
+    heroTextBottom: studio.heroTextBottom ?? "",
+    phone: studio.phone ?? "",
+    instagram: studio.instagram ?? "",
+    facebook: studio.facebook ?? "",
+  })
+
+  function update(field: string, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setIsSubmitting(true)
+    const result = await updateStudioSettings(form)
+    setIsSubmitting(false)
+    if (result.error) {
+      toast.error(result.error)
+    } else {
+      toast.success("Settings saved")
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>General</CardTitle>
+          <CardDescription>Studio name and branding.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="name">Studio Name</Label>
+            <Input id="name" value={form.name} onChange={(e) => update("name", e.target.value)} />
+          </div>
+          <ImageUploadField
+            label="Logo"
+            value={form.logo}
+            onChange={(url) => update("logo", url)}
+            context="studio"
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Hero Section</CardTitle>
+          <CardDescription>The main banner on your studio page.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <ImageUploadField
+            label="Background Image"
+            value={form.heroImage}
+            onChange={(url) => update("heroImage", url)}
+            context="studio"
+          />
+          <ImageUploadField
+            label="Portrait / Illustration"
+            value={form.heroPortrait}
+            onChange={(url) => update("heroPortrait", url)}
+            context="studio"
+          />
+          <div>
+            <Label htmlFor="heroTextLeft">Side Label</Label>
+            <Input id="heroTextLeft" value={form.heroTextLeft} onChange={(e) => update("heroTextLeft", e.target.value)} placeholder="Tattoo Artist" />
+          </div>
+          <div>
+            <Label htmlFor="heroTextCenter">Main Heading (use new lines for multiple rows)</Label>
+            <Textarea id="heroTextCenter" value={form.heroTextCenter} onChange={(e) => update("heroTextCenter", e.target.value)} placeholder={"Your\nStudio"} rows={2} />
+          </div>
+          <div>
+            <Label htmlFor="heroTextBottom">Tagline</Label>
+            <Input id="heroTextBottom" value={form.heroTextBottom} onChange={(e) => update("heroTextBottom", e.target.value)} placeholder="Your tagline goes here" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Contact & Social</CardTitle>
+          <CardDescription>Phone number and social media links.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="phone">Phone Number</Label>
+            <Input id="phone" value={form.phone} onChange={(e) => update("phone", e.target.value)} placeholder="+1234567890" />
+          </div>
+          <div>
+            <Label htmlFor="instagram">Instagram URL</Label>
+            <Input id="instagram" value={form.instagram} onChange={(e) => update("instagram", e.target.value)} placeholder="https://instagram.com/yourstudio" />
+          </div>
+          <div>
+            <Label htmlFor="facebook">Facebook URL</Label>
+            <Input id="facebook" value={form.facebook} onChange={(e) => update("facebook", e.target.value)} placeholder="https://facebook.com/yourstudio" />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? <><LoadingSpinner size="sm" className="mr-2" />Saving...</> : "Save Settings"}
+      </Button>
+    </form>
+  )
+}

--- a/tattooista-next/src/app/api/upload/route.ts
+++ b/tattooista-next/src/app/api/upload/route.ts
@@ -1,7 +1,28 @@
 import { NextRequest, NextResponse } from "next/server"
-import { put } from "@vercel/blob"
 import { auth } from "@/lib/auth"
-import { requireTenantContext, requireStudioRole } from "@/lib/tenant"
+import { requireSessionStudio, requireStudioRole } from "@/lib/tenant"
+import path from "path"
+import { writeFile, mkdir } from "fs/promises"
+
+async function uploadFile(file: File, context: string): Promise<string> {
+  // Production: use Vercel Blob
+  if (process.env.BLOB_READ_WRITE_TOKEN) {
+    const { put } = await import("@vercel/blob")
+    const blob = await put(`${context}/${file.name}`, file, { access: "public" })
+    return blob.url
+  }
+
+  // Local dev: save to public/uploads/
+  const uploadsDir = path.join(process.cwd(), "public", "uploads", context)
+  await mkdir(uploadsDir, { recursive: true })
+
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const uniqueName = `${Date.now()}_${file.name}`
+  const filePath = path.join(uploadsDir, uniqueName)
+  await writeFile(filePath, buffer)
+
+  return `/uploads/${context}/${uniqueName}`
+}
 
 export async function POST(request: NextRequest) {
   const session = await auth()
@@ -11,17 +32,17 @@ export async function POST(request: NextRequest) {
 
   const formData = await request.formData()
   const files = formData.getAll("files") as File[]
-  const context = formData.get("context") as string | null // e.g. "gallery", "avatar", "wallpaper", "review", "client"
+  const context = formData.get("context") as string | null
 
   if (files.length === 0) {
     return NextResponse.json({ error: "No files provided" }, { status: 400 })
   }
 
   // Admin-only contexts require studio membership
-  const adminContexts = ["gallery", "wallpaper", "client"]
+  const adminContexts = ["gallery", "wallpaper", "client", "studio"]
   if (context && adminContexts.includes(context)) {
     try {
-      const studio = await requireTenantContext()
+      const studio = await requireSessionStudio()
       await requireStudioRole(session.user.id, studio.id)
     } catch {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
@@ -36,10 +57,8 @@ export async function POST(request: NextRequest) {
   const uploaded: Array<{ url: string; name: string }> = []
 
   for (const file of files) {
-    const blob = await put(`${context || "uploads"}/${file.name}`, file, {
-      access: "public",
-    })
-    uploaded.push({ url: blob.url, name: file.name })
+    const url = await uploadFile(file, context || "uploads")
+    uploaded.push({ url, name: file.name })
   }
 
   return NextResponse.json({ files: uploaded })

--- a/tattooista-next/src/components/forms/style-form.tsx
+++ b/tattooista-next/src/components/forms/style-form.tsx
@@ -1,10 +1,12 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useRef } from "react"
 import { useRouter } from "next/navigation"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { toast } from "sonner"
+import { Upload, X } from "lucide-react"
+import { styleWallpaperUrl } from "@/lib/image-utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -36,6 +38,11 @@ interface StyleFormProps {
 export function StyleForm({ style, onSuccess }: StyleFormProps) {
   const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
+  const [previewUrl, setPreviewUrl] = useState<string | null>(
+    style?.wallPaper ? styleWallpaperUrl(style.id, style.wallPaper) : null
+  )
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const isEditing = !!style
 
   const form = useForm<StyleInput>({
@@ -47,6 +54,44 @@ export function StyleForm({ style, onSuccess }: StyleFormProps) {
       nonStyle: style?.nonStyle || false,
     },
   })
+
+  async function handleFileUpload(file: File) {
+    setIsUploading(true)
+    try {
+      const uploadData = new FormData()
+      uploadData.append("files", file)
+      uploadData.append("context", "wallpaper")
+
+      const response = await fetch("/api/upload", {
+        method: "POST",
+        body: uploadData,
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || "Upload failed")
+      }
+
+      const result = await response.json()
+      const uploadedUrl = result.files[0].url
+
+      form.setValue("wallPaper", uploadedUrl)
+      setPreviewUrl(uploadedUrl)
+      toast.success("Wallpaper uploaded!")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Upload failed")
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  function handleRemoveWallpaper() {
+    form.setValue("wallPaper", "")
+    setPreviewUrl(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""
+    }
+  }
 
   async function onSubmit(data: StyleInput) {
     setIsSubmitting(true)
@@ -114,11 +159,56 @@ export function StyleForm({ style, onSuccess }: StyleFormProps) {
         <FormField
           control={form.control}
           name="wallPaper"
-          render={({ field }) => (
+          render={() => (
             <FormItem>
-              <FormLabel>Wallpaper Image URL</FormLabel>
+              <FormLabel>Wallpaper Image</FormLabel>
               <FormControl>
-                <Input placeholder="https://..." {...field} />
+                <div className="space-y-3">
+                  {previewUrl ? (
+                    <div className="relative w-full h-40 rounded-lg overflow-hidden border border-border">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={previewUrl}
+                        alt="Style wallpaper preview"
+                        className="w-full h-full object-cover"
+                      />
+                      <button
+                        type="button"
+                        onClick={handleRemoveWallpaper}
+                        className="absolute top-2 right-2 p-1 rounded-full bg-black/60 text-white hover:bg-black/80 transition-colors"
+                      >
+                        <X className="h-4 w-4" />
+                      </button>
+                    </div>
+                  ) : (
+                    <label className="flex flex-col items-center justify-center w-full h-40 rounded-lg border-2 border-dashed border-border hover:border-primary/50 cursor-pointer transition-colors bg-muted/30">
+                      <div className="flex flex-col items-center gap-2 text-muted-foreground">
+                        {isUploading ? (
+                          <>
+                            <LoadingSpinner size="sm" />
+                            <span className="text-sm">Uploading...</span>
+                          </>
+                        ) : (
+                          <>
+                            <Upload className="h-8 w-8" />
+                            <span className="text-sm">Click to upload wallpaper image</span>
+                          </>
+                        )}
+                      </div>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        disabled={isUploading}
+                        onChange={(e) => {
+                          const file = e.target.files?.[0]
+                          if (file) handleFileUpload(file)
+                        }}
+                      />
+                    </label>
+                  )}
+                </div>
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -146,7 +236,7 @@ export function StyleForm({ style, onSuccess }: StyleFormProps) {
           )}
         />
 
-        <Button type="submit" disabled={isSubmitting}>
+        <Button type="submit" disabled={isSubmitting || isUploading}>
           {isSubmitting ? (
             <>
               <LoadingSpinner size="sm" className="mr-2" />

--- a/tattooista-next/src/components/platform-landing.tsx
+++ b/tattooista-next/src/components/platform-landing.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react"
 import { useSearchParams } from "next/navigation"
+import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
 import { CreateStudioForm } from "@/components/forms/create-studio-form"
 import { OwnerLoginForm } from "@/components/forms/owner-login-form"
 
@@ -60,6 +62,12 @@ export function PlatformLanding() {
             )}
           </CardContent>
         </Card>
+
+        <div className="text-center mt-6">
+          <Button variant="outline" asChild>
+            <Link href="/demo" target="_blank">See Demo Studio</Link>
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/tattooista-next/src/components/shared/gallery-infinite.tsx
+++ b/tattooista-next/src/components/shared/gallery-infinite.tsx
@@ -87,7 +87,7 @@ export function GalleryInfinite({
                   className="h-full bg-cover bg-no-repeat bg-center overflow-hidden cursor-pointer grayscale hover:grayscale-0 shadow-[0_0_5px_3px_rgba(250,250,250,0.07)] min-[990px]:relative min-[990px]:transition-all min-[990px]:duration-300 min-[990px]:ease-in-out min-[990px]:hover:scale-[1.4] min-[990px]:hover:shadow-[0_0_10px_7px_rgba(0,0,0,0.8)] min-[990px]:hover:z-10"
                   onClick={() => setFullViewIndex(index)}
                   style={{
-                    backgroundImage: `url(${galleryImageUrl(item.fileName)})`,
+                    backgroundImage: `url('${galleryImageUrl(item.fileName)}')`,
                   }}
                 />
               </li>

--- a/tattooista-next/src/components/shared/header.tsx
+++ b/tattooista-next/src/components/shared/header.tsx
@@ -18,35 +18,33 @@ const navItems = [
   { path: "/reviews", label: "Reviews" },
 ]
 
-const socialLinks = [
-  {
-    tooltipText: "My Instagram",
-    url: "https://www.instagram.com/adelainehobf/",
-    icon: "/icons/instagram.svg",
-  },
-  {
-    tooltipText: "My Facebook",
-    url: "https://www.facebook.com/a.hobf",
-    icon: "/icons/facebook.svg",
-  },
-]
-
 function studioHref(path: string, slug: string) {
-  // For hash links like /#about → /{slug}#about
   if (path.startsWith("/#")) {
     return `/${slug}${path.slice(1)}`
   }
-  // For regular paths like /portfolio → /{slug}/portfolio
   return `/${slug}${path}`
 }
 
-export function Header({ studioSlug }: { studioSlug: string }) {
+interface HeaderProps {
+  studioSlug: string
+  logo?: string | null
+  phone?: string | null
+  instagram?: string | null
+  facebook?: string | null
+}
+
+export function Header({ studioSlug, logo, phone, instagram, facebook }: HeaderProps) {
   const pathname = usePathname()
   const { data: session } = useSession()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const navRef = useRef<HTMLDivElement>(null)
 
   const isPortfolio = pathname.includes("/portfolio")
+
+  const socialLinks = [
+    instagram ? { tooltipText: "Instagram", url: instagram, icon: "/icons/instagram.svg" } : null,
+    facebook ? { tooltipText: "Facebook", url: facebook, icon: "/icons/facebook.svg" } : null,
+  ].filter(Boolean) as { tooltipText: string; url: string; icon: string }[]
 
   const handleLogout = async () => {
     await logout()
@@ -79,8 +77,8 @@ export function Header({ studioSlug }: { studioSlug: string }) {
       {/* Logo */}
       <Link href={`/${studioSlug}`} className="relative w-[50px] h-[50px] min-[990px]:w-[55px] min-[990px]:h-[88px] shrink-0">
         <Image
-          src="/images/logo.png"
-          alt="Tattooista"
+          src={logo || "/images/logo.png"}
+          alt="Studio"
           fill
           className="object-contain"
           priority
@@ -120,6 +118,7 @@ export function Header({ studioSlug }: { studioSlug: string }) {
       </div>
 
       {/* Social nav — hidden on mobile, visible on desktop */}
+      {socialLinks.length > 0 && (
       <nav className="hidden min-[990px]:block mr-4">
         <ul className="flex items-center gap-5 list-none m-0 p-0">
           {socialLinks.map((link) => (
@@ -143,6 +142,7 @@ export function Header({ studioSlug }: { studioSlug: string }) {
           ))}
         </ul>
       </nav>
+      )}
 
       {/* Desktop right section */}
       <div className="hidden min-[990px]:flex items-center gap-[50px] ml-auto">
@@ -157,8 +157,9 @@ export function Header({ studioSlug }: { studioSlug: string }) {
         )}
 
         <nav className="flex items-center gap-[40px]">
+          {phone && (
           <a
-            href="tel:+4745519015"
+            href={`tel:${phone}`}
             className="flex items-center gap-4 text-foreground font-normal bg-transparent border-none hover:[&_svg]:scale-[1.2] transition-all duration-300"
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -170,6 +171,7 @@ export function Header({ studioSlug }: { studioSlug: string }) {
             />
             Call me
           </a>
+          )}
           {session?.user && (
             <>
               <Link

--- a/tattooista-next/src/components/shared/portfolio-slider.tsx
+++ b/tattooista-next/src/components/shared/portfolio-slider.tsx
@@ -7,9 +7,10 @@ import { styleWallpaperUrl } from "@/lib/image-utils"
 
 type Props = {
   styles: TattooStyle[]
+  slug: string
 }
 
-export function PortfolioSlider({ styles }: Props) {
+export function PortfolioSlider({ styles, slug }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null)
   const [activeIndex, setActiveIndex] = useState(0)
 
@@ -55,7 +56,7 @@ export function PortfolioSlider({ styles }: Props) {
             className="group flex-shrink-0 w-[calc(100%-10px)] sm:w-[275px] md:w-[325px] h-full snap-start p-[5px]"
           >
             <Link
-              href={`/portfolio?style=${style.id}`}
+              href={`/${slug}/portfolio?style=${style.id}`}
               className="flex justify-center items-end pb-[20px] w-full h-full bg-cover bg-no-repeat bg-center grayscale group-hover:grayscale-0 transition-all duration-300"
               style={{
                 backgroundImage: style.wallPaper

--- a/tattooista-next/src/components/shared/style-slider.tsx
+++ b/tattooista-next/src/components/shared/style-slider.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useRef } from "react"
-import Link from "next/link"
 import { Swiper, SwiperSlide } from "swiper/react"
 import { Navigation } from "swiper/modules"
 import type { Swiper as SwiperClass } from "swiper"
@@ -18,6 +17,7 @@ type StyleItem = {
 type Props = {
   styles: StyleItem[]
   activeStyleId: string | null
+  onStyleSelect: (styleId: string) => void
 }
 
 const breakpoints = {
@@ -32,7 +32,7 @@ const breakpoints = {
   },
 }
 
-export function StyleSlider({ styles, activeStyleId }: Props) {
+export function StyleSlider({ styles, activeStyleId, onStyleSelect }: Props) {
   const swiperRef = useRef<SwiperClass | null>(null)
 
   const activeIndex = styles.findIndex((s) => s.id === activeStyleId)
@@ -57,9 +57,10 @@ export function StyleSlider({ styles, activeStyleId }: Props) {
       >
         {styles.map((style) => (
           <SwiperSlide key={style.id}>
-            <Link
-              href={`/portfolio?style=${style.id}`}
-              className={`flex items-center justify-center shrink-0 px-2 md:px-6 py-2 max-w-full text-lg md:text-[28px] font-semibold overflow-hidden border-2 cursor-pointer no-underline transition-all duration-300 ${
+            <button
+              type="button"
+              onClick={() => onStyleSelect(style.id)}
+              className={`flex items-center justify-center shrink-0 w-full px-2 md:px-6 py-2 max-w-full text-lg md:text-[28px] font-semibold overflow-hidden border-2 cursor-pointer no-underline transition-all duration-300 ${
                 activeStyleId === style.id
                   ? "bg-foreground text-background border-foreground hover:bg-foreground hover:text-background"
                   : "bg-transparent text-foreground border-foreground hover:bg-foreground hover:text-background"
@@ -68,7 +69,7 @@ export function StyleSlider({ styles, activeStyleId }: Props) {
               <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap capitalize">
                 {style.value}
               </span>
-            </Link>
+            </button>
           </SwiperSlide>
         ))}
       </Swiper>

--- a/tattooista-next/src/components/ui/alert-dialog.tsx
+++ b/tattooista-next/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/tattooista-next/src/components/ui/button.tsx
+++ b/tattooista-next/src/components/ui/button.tsx
@@ -5,15 +5,15 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:
@@ -23,7 +23,7 @@ const buttonVariants = cva(
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
         "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",

--- a/tattooista-next/src/lib/actions/studio.ts
+++ b/tattooista-next/src/lib/actions/studio.ts
@@ -1,0 +1,132 @@
+"use server"
+
+import { auth } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function updateStudioSettings(data: {
+  name: string
+  logo: string
+  heroImage: string
+  heroPortrait: string
+  heroTextLeft: string
+  heroTextCenter: string
+  heroTextBottom: string
+  phone: string
+  instagram: string
+  facebook: string
+}) {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { error: "Not authenticated" }
+  }
+
+  const studioSlug = session.user.studioSlug
+  if (!studioSlug) {
+    return { error: "No studio found" }
+  }
+
+  const studio = await prisma.studio.findUnique({
+    where: { slug: studioSlug },
+  })
+
+  if (!studio) {
+    return { error: "Studio not found" }
+  }
+
+  const membership = await prisma.studioMembership.findUnique({
+    where: {
+      userId_studioId: {
+        userId: session.user.id,
+        studioId: studio.id,
+      },
+    },
+  })
+
+  if (!membership || membership.role !== "OWNER") {
+    return { error: "Only the studio owner can update settings" }
+  }
+
+  await prisma.studio.update({
+    where: { id: studio.id },
+    data: {
+      name: data.name || studio.name,
+      logo: data.logo || null,
+      heroImage: data.heroImage || null,
+      heroPortrait: data.heroPortrait || null,
+      heroTextLeft: data.heroTextLeft || null,
+      heroTextCenter: data.heroTextCenter || null,
+      heroTextBottom: data.heroTextBottom || null,
+      phone: data.phone || null,
+      instagram: data.instagram || null,
+      facebook: data.facebook || null,
+    },
+  })
+
+  return { success: true }
+}
+
+export async function getStudioSettings() {
+  const session = await auth()
+  if (!session?.user?.id) return null
+
+  const studioSlug = session.user.studioSlug
+  if (!studioSlug) return null
+
+  return prisma.studio.findUnique({
+    where: { slug: studioSlug },
+    select: {
+      name: true,
+      slug: true,
+      logo: true,
+      heroImage: true,
+      heroPortrait: true,
+      heroTextLeft: true,
+      heroTextCenter: true,
+      heroTextBottom: true,
+      phone: true,
+      instagram: true,
+      facebook: true,
+    },
+  })
+}
+
+export async function deleteStudio() {
+  const session = await auth()
+  if (!session?.user?.id) {
+    return { error: "Not authenticated" }
+  }
+
+  const studioSlug = session.user.studioSlug
+  if (!studioSlug) {
+    return { error: "No studio found" }
+  }
+
+  const studio = await prisma.studio.findUnique({
+    where: { slug: studioSlug },
+  })
+
+  if (!studio) {
+    return { error: "Studio not found" }
+  }
+
+  // Verify the user is the owner
+  const membership = await prisma.studioMembership.findUnique({
+    where: {
+      userId_studioId: {
+        userId: session.user.id,
+        studioId: studio.id,
+      },
+    },
+  })
+
+  if (!membership || membership.role !== "OWNER") {
+    return { error: "Only the studio owner can delete the studio" }
+  }
+
+  // Delete everything — Prisma cascades handle related records
+  await prisma.studio.delete({
+    where: { id: studio.id },
+  })
+
+  return { success: true }
+}

--- a/tattooista-next/src/lib/actions/styles.ts
+++ b/tattooista-next/src/lib/actions/styles.ts
@@ -76,19 +76,29 @@ export async function createStyle(formData: FormData) {
     return { error: "A style with this name already exists" }
   }
 
-  const style = await prisma.tattooStyle.create({
-    data: {
-      studioId: studio.id,
-      value: data.value,
-      description: data.description || null,
-      wallPaper: data.wallPaper || null,
-      nonStyle: data.nonStyle || false,
-    },
-  })
+  try {
+    const style = await prisma.tattooStyle.create({
+      data: {
+        studioId: studio.id,
+        value: data.value,
+        description: data.description || null,
+        wallPaper: data.wallPaper || null,
+        nonStyle: data.nonStyle || false,
+      },
+    })
 
-  revalidatePath("/[slug]/admin/styles", "page")
-  revalidatePath("/portfolio")
-  return { success: true, data: style }
+    revalidatePath("/[slug]/admin/styles", "page")
+    revalidatePath("/portfolio")
+    return { success: true, data: style }
+  } catch (err: unknown) {
+    if (
+      err instanceof Error &&
+      err.message.includes("Unique constraint")
+    ) {
+      return { error: "A style with this name already exists" }
+    }
+    throw err
+  }
 }
 
 export async function updateStyle(id: string, formData: FormData) {
@@ -111,10 +121,11 @@ export async function updateStyle(id: string, formData: FormData) {
 
   const data = validationResult.data
 
-  // Check if another style with same name exists
+  // Check if another style with same name exists in this studio
   if (data.value) {
     const existing = await prisma.tattooStyle.findFirst({
       where: {
+        studioId: studio.id,
         value: data.value,
         NOT: { id },
       },

--- a/tattooista-next/src/lib/image-utils.ts
+++ b/tattooista-next/src/lib/image-utils.ts
@@ -16,6 +16,7 @@ function isRelativePath(value: string): boolean {
 
 export function galleryImageUrl(fileName: string): string {
   if (isExternalUrl(fileName)) return fileName
+  if (isRelativePath(fileName)) return fileName.startsWith("/") ? fileName : `/${fileName}`
   return `/gallery/${fileName}`
 }
 

--- a/tattooista-next/src/lib/studio.ts
+++ b/tattooista-next/src/lib/studio.ts
@@ -29,6 +29,128 @@ export function validateStudioCreation(
   return { valid: true }
 }
 
+// Default tattoo styles — same as the MERN app / seed data
+const DEFAULT_STYLES = [
+  {
+    value: "FineLine",
+    description:
+      "Fine line tattooing consists of distinct straight or curved thin lines, without gradations in shade or color to represent 2D or 3D objects, emphasizing form and outline over color, shading, and texture. These tattoos can have incredible levels of detail built in, without being 'loud' about it.",
+    wallPaper: "styles/mg_63bf36c2c3cf5018e63959ea/1705989076302_90345086fd58.jpg",
+    nonStyle: false,
+  },
+  {
+    value: "Black@Gray",
+    description:
+      'Black-and-gray is sometimes referred to as "jailhouse" or "joint style" and is thought to have originated in prisons where inmates had limited access to different materials; they resorted to using guitar strings for needles and used cigarette ashes or pen ink to produce tattoos.',
+    wallPaper: "styles/mg_650349d7f56daad5f49df4e9/1705990192452_15d45932b76c.jpg",
+    nonStyle: false,
+  },
+  {
+    value: "No Style",
+    description:
+      "Here the images of tattoos which difficult to define which style it is actually",
+    wallPaper: "styles/mg_655a218dbf8c718670be6a58/1712734019347_0e6f74759321.jpg",
+    nonStyle: true,
+  },
+  {
+    value: "BlackWork",
+    description:
+      "A blackwork tattoo is a bold work of body art rendered in solid planes of black ink. Usually, these tattoos are composed of abstract patterns and geometric shapes, though some feature figurative forms and recognizable scenes and subjects.",
+    wallPaper: "styles/mg_65ad683491d96372e7947ad8/1705988606001_eb5bfbe27e4e.jpg",
+    nonStyle: false,
+  },
+  {
+    value: "NeoTraditional",
+    description:
+      "Neo-traditional tattoo designs feature bold, dark outlines and illustrative looks. There is a feeling of subtle dimension and the use of saturated colors. This dimension is not a 3D type of tattoo, yet they contain lines that vary in weight. This style of tattoo art consists of an illustrated look.",
+    wallPaper: "styles/mg_65ad685191d96372e7947add/1705988298732_06afd4950285.jpg",
+    nonStyle: false,
+  },
+  {
+    value: "Realistic",
+    description:
+      "Realism tattoos can depict anything, with the only requirement being that the tattoo looks as close to photorealistic as possible. Portraits of famous people, loved ones, nature, and meaningful objects are all common choices for realistic tattoos.",
+    wallPaper: "styles/mg_65be73db5b50bdfa55dabf00/1716730967403_9696c3542d5b.jpg",
+    nonStyle: false,
+  },
+  {
+    value: "Designs",
+    description: "Here you can see some of my designs and drawings.",
+    wallPaper: "styles/mg_663602db8b824c641813786e/1715001956431_728b5fd67cd6.jpg",
+    nonStyle: false,
+  },
+]
+
+const DEFAULT_SERVICES = [
+  {
+    title: "TATTOO SESSION",
+    conditions:
+      "1000 kr -minimum cost up to one hour\n1000 kr/hour - no longer then 4 hours\n700 kr/hour cost for each next hour if session longer then 4 hours\nmax session 90 hours",
+    order: 0,
+  },
+  {
+    title: "CAVER UP",
+    conditions:
+      "1000 kr -minimum cost up to one hour\n1000 kr/hour - no longer then 4 hours\n700 kr/hour cost for each next hour if session longer then 4 hours\nmax session 6 hours",
+    order: 1,
+  },
+  {
+    title: "INDIVIDUAL DESIGN",
+    conditions:
+      "1000 kr -minimum cost up to one hour\n1000 kr/hour - no longer then 4 hours\n700 kr/hour cost for each next hour if session longer then 4 hours\nmax session 6 hours",
+    order: 2,
+  },
+  {
+    title: "CONSULTATION",
+    conditions:
+      "1000 kr -minimum cost up to one hour\n1000 kr/hour - no longer then 4 hours\n700 kr/hour cost for each next hour if session longer then 4 hours\nmax session 6 hours",
+    order: 3,
+  },
+]
+
+const DEFAULT_FAQ = [
+  {
+    question: "IS IT SAFE TO GET A TATTOO?",
+    answer:
+      "Tattoos breach the skin, which means that skin infections and other complications are possible, including: allergic reactions, skin infections and other skin problems. From my side I can guarantee that your tattoo will be done by all hygienic standards and if you will follow my tips and look after your fresh tattoo together we can minimize that risk.",
+    order: 0,
+  },
+  {
+    question: "HOW TO LOOK AFTER YOU FRESH TATTOO?",
+    answer:
+      "Stay away from dust, dirt, direct sun rays, pools, saunas etc - especially for the first week after it is done, also first 2-3 days it is very important to wash your fresh tattoo every 4-5 hours with a soft soap, dry it and grease.",
+    order: 1,
+  },
+  {
+    question: "RECOMMENDATION BEFORE SESSION?",
+    answer:
+      "Before session have a good meal, get shower, change your cloth. If you getting late - write a message, if you going to cancel - do it beforehand, let respect each other.",
+    order: 2,
+  },
+  {
+    question: "CAN I GET A TATTOO IF I AM UNDER 18?",
+    answer:
+      "If you are under 18 then you gonna need your parents permission, your mom or dad need to say me personally, that they do not mind you having a tattoo.",
+    order: 3,
+  },
+  {
+    question: "DO YOU PROVIDE ANT ANESTHESIA WHILE TATTOOING?",
+    answer: "In some cases I do, but you'll need to preorder it.",
+    order: 4,
+  },
+  {
+    question: "HOW LONG CAN BE A ONE TATTOO SESSION?",
+    answer:
+      "Up to 6 hours, in this case we gonna have few brakes. Bring your snacks!))",
+    order: 5,
+  },
+  {
+    question: "DO YOU REMOVE TATTOO?",
+    answer: "Long story - short - I don't.",
+    order: 6,
+  },
+]
+
 export async function createStudioWithDefaults(
   ownerId: string,
   input: StudioCreationInput,
@@ -48,6 +170,13 @@ export async function createStudioWithDefaults(
       name: input.name.trim(),
       slug: input.slug,
       logo: input.logo ?? null,
+      heroImage: "/images/body-bg.jpg",
+      heroTextLeft: "Tattoo Artist",
+      heroTextCenter: "Your\nStudio",
+      heroTextBottom: "Your tagline goes here",
+      phone: "+1234567890",
+      instagram: "#",
+      facebook: "#",
     },
   })
 
@@ -59,20 +188,60 @@ export async function createStudioWithDefaults(
     },
   })
 
+  // Pages
   await client.page.createMany({
     data: [
-      { studioId: studio.id, name: "about", isActive: true },
-      { studioId: studio.id, name: "contacts", isActive: true },
+      {
+        studioId: studio.id,
+        name: "about",
+        title: "Hey!! It is me",
+        content:
+          "gdfgsdfgiusto odio dignissimos ducimus qui blanditiis praesentium volusdgsdgsdgptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus. Temporibus autem quibusdam et aut officiis debitis aut rerum necessitatibus saepe eveniet ut et voluptates repudiandae sint et molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut perferendis doloribus asperiores repellat",
+        isActive: true,
+      },
+      {
+        studioId: studio.id,
+        name: "contacts",
+        title: "Get in Touch",
+        content:
+          "We'd love to hear from you! Whether you have questions about our services or want to book a consultation, don't hesitate to reach out.",
+        isActive: true,
+      },
     ],
   })
 
-  await client.tattooStyle.create({
-    data: {
-      studioId: studio.id,
-      value: "Other",
-      nonStyle: true,
-    },
-  })
+  // Tattoo styles — all defaults with wallpapers
+  for (const style of DEFAULT_STYLES) {
+    await client.tattooStyle.create({
+      data: {
+        studioId: studio.id,
+        value: style.value,
+        description: style.description,
+        nonStyle: style.nonStyle,
+        wallPaper: style.wallPaper,
+      },
+    })
+  }
+
+  // Services
+  for (const service of DEFAULT_SERVICES) {
+    await client.service.create({
+      data: {
+        studioId: studio.id,
+        ...service,
+      },
+    })
+  }
+
+  // FAQ
+  for (const faq of DEFAULT_FAQ) {
+    await client.faqItem.create({
+      data: {
+        studioId: studio.id,
+        ...faq,
+      },
+    })
+  }
 
   return studio
 }

--- a/tattooista-next/src/lib/validations/style.ts
+++ b/tattooista-next/src/lib/validations/style.ts
@@ -6,7 +6,7 @@ export const styleSchema = z.object({
     .min(2, "Style name must be at least 2 characters")
     .max(50, "Style name is too long"),
   description: z.string().max(1000, "Description is too long").optional(),
-  wallPaper: z.string().url().optional().or(z.literal("")),
+  wallPaper: z.string().optional().or(z.literal("")),
   nonStyle: z.boolean().optional(),
 })
 


### PR DESCRIPTION
…igation

 - Style form: replace wallpaper URL text input with file upload + preview
  - Gallery upload: two-step flow — pick files, preview thumbnails, remove unwanted, select styles, then submit (matches original MERN UX)
  - Gallery upload requires at least one style before submitting
  - Portfolio: style switching is now client-side (no URL change, no 404)          - Portfolio: home page carousel links to correct /{slug}/portfolio?style=            - Fix duplicate style creation via DB unique constraint catch (race condition)          - Fix updateStyle duplicate check scoped to studio (was cross-tenant)
  - Fix galleryImageUrl for uploaded paths (was double-prefixing /gallery/)
  - Fix gallery background-image CSS quoting for filenames with spaces
  - Fix style form wallpaper preview for seed data paths (leading slash)
  - Studio settings, delete studio, header, button, layout updates