### PR TITLE
Wire GitHub Projects board into the feature/bug doc workflow

### DIFF
--- a/.claude/bugs/INDEX.md
+++ b/.claude/bugs/INDEX.md
@@ -4,5 +4,5 @@
 > Used by the FIX phase to surface regression warnings when a prior fix touched the same files/area.
 > Only **fixed** bugs land here — bugs closed as "not a bug" do not.
 
-| Date | Area | Title | Files | Commit | Takeaway |
-|---|---|---|---|---|---|
+| Issue | Date | Area | Title | Files | Commit | Takeaway |
+|---|---|---|---|---|---|---|

--- a/.claude/bugs/TEMPLATE.md
+++ b/.claude/bugs/TEMPLATE.md
@@ -3,6 +3,9 @@
 ## Status
 IN PROGRESS
 
+## Issue
+{GitHub issue URL — the board card, e.g. https://github.com/Menolas/Tattooista/issues/42}
+
 ## Branch
 {git branch}
 

--- a/.claude/features/_TEMPLATE.md
+++ b/.claude/features/_TEMPLATE.md
@@ -3,6 +3,9 @@
 ## Status
 {IN PROGRESS | SHIPPED | committed locally / pushed / merged — be specific about git state}
 
+## Issue
+{GitHub issue URL — the board card, e.g. https://github.com/Menolas/Tattooista/issues/42}
+
 ## Goal
 {One or two sentences: what this feature does and why it exists.}
 

--- a/.claude/github-board.md
+++ b/.claude/github-board.md
@@ -1,0 +1,71 @@
+# GitHub board — cheat sheet
+
+The board is **GitHub Projects** (Board view). Issues are the cards; the
+`.claude/features/` and `.claude/bugs/` docs hold the deep context. An issue
+`#42` maps to doc slug `42-<short-name>`.
+
+## One-time
+
+```bash
+gh auth status                       # must be logged in
+bash scripts/setup-github-labels.sh  # create the label set
+```
+
+Find your project number (shown in the Project URL, or):
+
+```bash
+gh project list --owner @me
+```
+
+Set these once per shell (replace with yours):
+
+```bash
+export GH_PROJECT=1          # your project number
+export GH_OWNER=@me          # or your org/login
+```
+
+## File an issue (creates the card)
+
+Easiest from the web (uses the Bug/Feature templates). From the terminal:
+
+```bash
+gh issue create --title "[Bug]: portfolio leaks across studios" \
+  --label "type:bug,area:tenant,priority:high" --body "…"
+```
+
+Add it to the board (if the auto-add workflow isn't on):
+
+```bash
+gh project item-add "$GH_PROJECT" --owner "$GH_OWNER" \
+  --url "$(gh issue view <#> --json url -q .url)"
+```
+
+## Work it
+
+```bash
+# Bugs go through the skill, which names the doc <issue#>-<slug>:
+/bug 42
+
+# Features: build via /feature, then doc lives at .claude/features/42-<slug>.md
+```
+
+Reference the issue in commits/PRs so the board auto-moves to Done:
+
+```bash
+git commit -m "Fix portfolio studio leak
+
+Closes #42"
+```
+
+`Closes #42` / `Fixes #42` in the PR or merge commit closes the issue, and the
+"Issue closed → Done" / "PR merged → Done" workflows move the card.
+
+## Triage / view
+
+```bash
+gh issue list --label "type:bug" --state open
+gh project item-list "$GH_PROJECT" --owner "$GH_OWNER"
+```
+
+> The board is the overview; the `.claude/` doc is the depth. Keep the issue
+> number in the doc and the doc reference in the issue so they stay linked.

--- a/.claude/skills/bug/SKILL.md
+++ b/.claude/skills/bug/SKILL.md
@@ -16,8 +16,10 @@ Every fixed bug leaves a trail, mirroring the feature docs:
 - **Archived** (fixed, committed): `.claude/bugs/archived/{slug}.md`
 - **Index** (append-only regression log): `.claude/bugs/INDEX.md`
 
-`{slug}` is a plain descriptive kebab-case name (no ticket system here) — e.g.
-`portfolio-leaks-across-studios`, `avatar-404-on-vercel`.
+`{slug}` is `<issue#>-<kebab-name>` from the GitHub issue (the board card) —
+e.g. `42-portfolio-leaks-across-studios`. No issue yet? Use a plain kebab name
+and add the issue link to the doc's `## Issue` once it exists. See
+`.claude/github-board.md`.
 
 Create a TodoWrite item per phase and work them in order.
 
@@ -43,10 +45,13 @@ Create a TodoWrite item per phase and work them in order.
       - Local Postgres is NOT prod Neon. Confirm the data assumption holds in the
         environment where the bug actually occurs.
 
-- [ ] **3. Scope tasks with the user, then create bug.md.** Read
+- [ ] **3. Read the issue, scope tasks, then create bug.md.** If an issue
+      number/URL was given, read it (`gh issue view <#>`) — repro/expected/actual
+      and Area usually come straight from the Bug template. Read
       `.claude/bugs/TEMPLATE.md`, create `.claude-local/bugs/active/{slug}/bug.md`,
-      and fill: title, `## Status: IN PROGRESS`, `## Branch` (current), `## Environment`,
-      `## Area`, `## Bug Summary` (repro/expected/actual/affected), `## Tasks → To Do`.
+      and fill: title, `## Status: IN PROGRESS`, `## Issue` (the issue URL),
+      `## Branch` (current), `## Environment`, `## Area`,
+      `## Bug Summary` (repro/expected/actual/affected), `## Tasks → To Do`.
 
 ## FIX — one task at a time (assess → approve → implement → complete)
 
@@ -85,8 +90,9 @@ Create a TodoWrite item per phase and work them in order.
 
 - [ ] **10. Append to INDEX.** Insert a row at the top of the table in
       `.claude/bugs/INDEX.md`:
-      `| {YYYY-MM-DD} | {area} | {title} | {comma-separated files} | {short sha or "pending"} | {takeaway} |`
-      (use `pending` for the commit until the user commits).
+      `| {#issue or "—"} | {YYYY-MM-DD} | {area} | {title} | {comma-separated files} | {short sha or "pending"} | {takeaway} |`
+      (use `pending` for the commit until the user commits). Suggest `Closes #<issue>`
+      in the commit/PR so the board card auto-moves to Done.
 
 - [ ] **11. Think before pushing.** Before any `git push`, verify:
       1. Will this work on Vercel (not just localhost)?
@@ -107,4 +113,4 @@ with or undo it. Inform-only; the user decides relevance.
 
 If it turns out not to be a bug: revert any exploratory changes, `rm -rf` the active
 `.claude-local/bugs/active/{slug}/` dir, and do NOT add a row to INDEX (only real fixes
-become project knowledge).
+become project knowledge). Suggest the user close the GitHub issue with the reason.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,55 @@
+name: Bug
+description: Something is broken or behaving unexpectedly
+title: "[Bug]: "
+labels: ["type:bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Filing this creates the board card. When you start the fix, the `bug`
+        skill turns it into `.claude-local/bugs/active/<issue#>-<slug>/bug.md`.
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Where does it actually reproduce? (Local Postgres is NOT prod Neon.)
+      options:
+        - Local (Docker Postgres)
+        - Vercel (Neon prod)
+        - Both
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      description: Feature-area tag (used for grouping + regression warnings).
+      placeholder: tenant-isolation, image-rendering, auth, admin-dashboard, portfolio, seed
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual
+    validations:
+      required: true
+  - type: input
+    id: affected
+    attributes:
+      label: Affected
+      placeholder: URLs, components, studios, viewports

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+# Nudge toward the structured templates so issues and .claude/ docs share a shape.
+# Flip to `true` if you ever want plain blank issues again.
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature
+description: Build a new page, component, model, or capability
+title: "[Feature]: "
+labels: ["type:feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Filing this creates the board card. When you build it, the feature gets a
+        doc at `.claude/features/<issue#>-<slug>.md` (see `_TEMPLATE.md`).
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What this does and why it exists (one or two sentences).
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What's in. What's explicitly out / deferred.
+  - type: dropdown
+    id: mern
+    attributes:
+      label: MERN source of truth
+      description: Is there an original in Client/ to reproduce, or is this net-new?
+      options:
+        - Migrated from Client/ (reproduce the original exactly)
+        - Net-new (no original)
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      placeholder: portfolio, booking, reviews, admin, platform-landing
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Constraints, multi-tenant considerations, anything else.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,15 +44,19 @@ When building a new feature, page, component, or model:
 
 1. **Brainstorm/plan first**, then build via the `feature-dev:feature-dev` skill. Use the `tattooista-styling` skill for ALL UI/styling work. (There is intentionally no custom "feature" skill — these conventions live here in CLAUDE.md.)
 2. **Multi-tenant by default** — see Architecture below. Any new model gets a `studioId`; any tenant-scoped query resolves the current studio and filters by it, and gets a `vitest` test in `tattooista-next/tests/lib/`.
-3. **Every feature gets a doc** in `.claude/features/<slug>.md` (template: `.claude/features/_TEMPLATE.md`). Create it while building and keep it current — the feature is not done until the doc exists. A feature without a doc leaves no trail.
+3. **Every feature gets a doc** in `.claude/features/<slug>.md` (template: `.claude/features/_TEMPLATE.md`). Create it while building and keep it current — the feature is not done until the doc exists. A feature without a doc leaves no trail. When the work has a GitHub issue (the board card), the slug is `<issue#>-<name>` and the doc's `## Issue` links it.
 
 ## Fixing a bug
 
-Use the `bug` skill — it drives a documented lifecycle: working state in `.claude-local/bugs/active/<slug>/bug.md` (gitignored), then on fix it's **archived** to `.claude/bugs/archived/<slug>.md` and a row is appended to `.claude/bugs/INDEX.md` (the append-only regression-warning log). Before changing files, check INDEX.md for prior fixes in the same area. No ticket system — slugs are plain descriptive names.
+Use the `bug` skill — it drives a documented lifecycle: working state in `.claude-local/bugs/active/<slug>/bug.md` (gitignored), then on fix it's **archived** to `.claude/bugs/archived/<slug>.md` and a row is appended to `.claude/bugs/INDEX.md` (the append-only regression-warning log). Before changing files, check INDEX.md for prior fixes in the same area.
+
+## Task board (GitHub Projects)
+
+Work is tracked on a GitHub Projects board where **issues are the cards**. An issue `#42` maps to doc slug `42-<short-name>`; the doc links the issue, the issue gets the deep context from the doc. Reference `Closes #42` in commits/PRs so the board auto-moves to Done. Terminal recipes: `.claude/github-board.md`. Labels: `scripts/setup-github-labels.sh`.
 
 ## Read the feature/bug doc first; cite a source
 
-- **READ THE DOC FIRST.** Before answering anything about a feature under active development, read its `.claude/features/<slug>.md` doc; for anything about a past bug, read `.claude/bugs/INDEX.md` (and the archived bug doc it points to). Read the relevant source in full too, THEN answer. Decisions, file locations, and prior context are already written down — don't re-derive or ask what the doc answers.
+- **READ THE DOC FIRST.** Before answering anything about a feature under active development, read its `.claude/features/<slug>.md` doc (and its linked GitHub issue); for anything about a past bug, read `.claude/bugs/INDEX.md` (and the archived bug doc it points to). Read the relevant source in full too, THEN answer. Decisions, file locations, and prior context are already written down — don't re-derive or ask what the doc answers.
 - **CITE A SOURCE FOR EVERY PROJECT CLAIM, OR SAY "I DON'T KNOW."** Any statement about how this project/feature works must be backed by a specific file, line, or quote. If you can't point to one, say you don't know and go read. Never answer from conversation momentum or assumption.
 
 ---

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# One-time: create the Tattooista label set on GitHub.
+# Requires the GitHub CLI, authenticated: `gh auth status`.
+# Run from anywhere inside the repo:  bash scripts/setup-github-labels.sh
+#
+# `--force` updates a label if it already exists, so this is safe to re-run.
+set -euo pipefail
+
+create() { gh label create "$1" --color "$2" --description "$3" --force; }
+
+# Type
+create "type:bug"        "d73a4a" "Something is broken or behaving unexpectedly"
+create "type:feature"    "0e8a16" "New page, component, model, or capability"
+create "type:chore"      "fef2c0" "Tooling, docs, refactor — no user-facing behavior"
+
+# Priority
+create "priority:high"   "b60205" "Do this next"
+create "priority:medium" "fbca04" "Soon"
+create "priority:low"    "c2e0c6" "Eventually"
+
+# Area (match the tags used in .claude/bugs + .claude/features docs)
+create "area:tenant"     "5319e7" "Multi-tenant / studioId scoping"
+create "area:auth"       "0052cc" "Login, register, sessions, NextAuth"
+create "area:db"         "006b75" "Prisma, schema, seed, migrations"
+create "area:images"     "1d76db" "image-utils, wallpapers, gallery, avatars"
+create "area:ui"         "bfd4f2" "Styling, layout, components"
+create "area:platform"   "d4c5f9" "Platform landing / marketing, non-tenant"
+
+echo "Done. View: gh label list"


### PR DESCRIPTION
Issues are the board cards; an issue #N maps to doc slug N-<name>. Add bug + feature issue-form templates (mirroring the .claude doc templates), a label setup script, and a board cheat-sheet. Re-wire the conventions: feature/bug slugs become <issue#>-<name>, templates gain an Issue field, INDEX.md gains an Issue column, and the bug skill reads the issue and suggests Closes #N so the card auto-moves to Done.