### PR TITLE
Stop auth errors from lying about what went wrong

### DIFF
--- a/tattooista-next/docs/go-live.md
+++ b/tattooista-next/docs/go-live.md
@@ -23,6 +23,7 @@ Decisions and standing rules: `legal-decisions.md`. Umbrella traps: `~/.claude/s
 
 ## Blocking — before letting a stranger sign up
 
+- [ ] 💻 Let one person own more than one studio; signup refuses a second studio for the same email, which contradicts the selling point.
 - [ ] 💻 Limit failed sign-in and registration attempts, counted both per account and per network address.
 - [ ] 💻 Accept only real image files in the upload route and cap each file at 10 megabytes.
 - [ ] 💻 Add an error page to the sign-in area and a root-level error page for the whole app.
@@ -78,7 +79,6 @@ Decisions and standing rules: `legal-decisions.md`. Umbrella traps: `~/.claude/s
 
 ## Done
 
-- [x] 2026-08-16 💻 When saving a subscription status, refuse to replace a final status with an earlier one that arrives late.
 - [x] 2026-08-09 📋 Decide the plan split: free is one owner seat, 50 client cards, 500 megabytes of images; PRO lifts all three.
 - [x] 2026-08-09 📋 Decide against a free trial; the free tier replaces it.
 - [x] 2026-08-09 💻 Confirm the shipped terms never contained the trial promise; nothing to remove.
@@ -90,6 +90,7 @@ Decisions and standing rules: `legal-decisions.md`. Umbrella traps: `~/.claude/s
 - [x] 2026-08-09 💻 Build the notification handler: signature check, grant-only-on-confirmation, safe against duplicates.
 - [x] 2026-08-09 💻 Drop the separate token endpoint; the public client token in the environment replaces it.
 - [x] 2026-08-09 📋 Create the Paddle notification destination for subscription events; secret stored in the environment.
+- [x] 2026-08-16 💻 Refuse out-of-order Paddle events: paddleEventAt and paddleStatus on Studio, tested.
 - [x] 2026-08-09 📋 Decide the PRO prices: 14 euro monthly, 140 euro yearly — two months free.
 - [x] 2026-03-21 💻 Build email-and-password sign-in with sessions, verification and password reset.
 - [x] 2026-03-21 💻 Send all transactional mail through one shared mailer (src/lib/email.ts).

--- a/tattooista-next/src/lib/actions/auth.ts
+++ b/tattooista-next/src/lib/actions/auth.ts
@@ -12,6 +12,16 @@ import { sendVerificationEmail, sendPasswordResetEmail } from "@/lib/email"
 import { revalidatePath } from "next/cache"
 import { AuthError, CredentialsSignin } from "next-auth"
 
+/**
+ * A signup failure whose message was written for the person reading it.
+ *
+ * The transaction below throws for reasons the user can act on ("that URL is taken").
+ * Everything else it can throw — a Prisma error, a dropped connection — is internal and
+ * must never reach the form: a raw `prisma.studio.findUnique()` error surfaced verbatim
+ * on the signup page once, which told the user nothing and leaked schema details.
+ */
+class StudioSignupError extends Error {}
+
 export async function login(formData: FormData) {
   const rawData = {
     email: formData.get("email"),
@@ -39,6 +49,12 @@ export async function login(formData: FormData) {
         case "CredentialsSignin":
           if ((error as CredentialsSignin).code === "email_not_verified") {
             return { error: "Please verify your email before logging in. Check your inbox, or request a new verification email." }
+          }
+          // The password was right; the account simply owns no studio, so there is
+          // nowhere to sign in to. Saying "invalid password" sends people round the
+          // password-reset loop forever, which is exactly what it did.
+          if ((error as CredentialsSignin).code === "no_studio") {
+            return { error: "This email has no studio, so there is nothing to sign in to. Create a studio to get started." }
           }
           return { error: "Invalid email or password" }
         default:
@@ -294,15 +310,20 @@ export async function createStudio(formData: FormData) {
   let verificationToken: string
   try {
     const result = await prisma.$transaction(async (tx) => {
-      // Check email not taken
+      // Check email not taken. Accounts and studios are created together here, so an
+      // existing email USUALLY means an existing studio — but not always: rows left by
+      // the retired register() own nothing, and claiming they have a studio sends the
+      // person hunting for one that does not exist.
       const existingUser = await tx.user.findUnique({
         where: { email },
+        select: { _count: { select: { memberships: true } } },
       })
       if (existingUser) {
-        // An account always owns a studio — accounts and studios are created together
-        // here, and authorize() refuses any row that has neither. So an existing email
-        // does mean an existing studio.
-        throw new Error("This email is already associated with a studio on our platform. Please use a different email or sign in to your existing studio.")
+        throw new StudioSignupError(
+          existingUser._count.memberships > 0
+            ? "This email is already associated with a studio on our platform. Please use a different email or sign in to your existing studio."
+            : "This email is already registered but owns no studio, so it cannot be used to create one. Please use a different email, or contact support to have it released."
+        )
       }
 
       // Check slug not taken
@@ -310,7 +331,7 @@ export async function createStudio(formData: FormData) {
         where: { slug },
       })
       if (existingStudio) {
-        throw new Error(`The URL "${slug}" is already taken. Try a different studio name.`)
+        throw new StudioSignupError(`The URL "${slug}" is already taken. Try a different studio name.`)
       }
 
       // Create user
@@ -348,10 +369,11 @@ export async function createStudio(formData: FormData) {
 
     verificationToken = result.token
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof StudioSignupError) {
       return { error: error.message }
     }
-    return { error: "Failed to create studio. Please try again." }
+    console.error("createStudio failed:", error)
+    return { error: "We couldn't create your studio right now. Please try again in a few minutes." }
   }
 
   // Send email outside transaction — failure here doesn't roll back the DB.

--- a/tattooista-next/tests/lib/auth-actions.test.ts
+++ b/tattooista-next/tests/lib/auth-actions.test.ts
@@ -8,11 +8,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 
 // vi.mock is hoisted above the module body, so the mock objects have to be
 // built inside vi.hoisted() to exist by the time the factories run.
-const { prisma, auth, sendPasswordResetEmail, sendVerificationEmail } = vi.hoisted(() => {
+const { prisma, auth, signIn, sendPasswordResetEmail, sendVerificationEmail } = vi.hoisted(() => {
   return {
     auth: vi.fn(),
+    signIn: vi.fn(),
     prisma: {
-      user: { findUnique: vi.fn(), update: vi.fn() },
+      $transaction: vi.fn(),
+      user: { findUnique: vi.fn(), update: vi.fn(), create: vi.fn() },
+      studio: { findUnique: vi.fn() },
       studioMembership: { findFirst: vi.fn() },
       passwordResetToken: {
         findUnique: vi.fn(),
@@ -33,14 +36,20 @@ const { prisma, auth, sendPasswordResetEmail, sendVerificationEmail } = vi.hoist
 })
 
 vi.mock("@/lib/prisma", () => ({ prisma }))
-vi.mock("@/lib/auth", () => ({ signIn: vi.fn(), signOut: vi.fn(), auth }))
+vi.mock("@/lib/auth", () => ({ signIn, signOut: vi.fn(), auth }))
 // actions/auth.ts imports AuthError from next-auth directly; loading the real
 // package pulls in next/server, which does not resolve under the node runner.
 vi.mock("next-auth", () => ({ AuthError: class AuthError extends Error {} }))
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }))
 vi.mock("@/lib/email", () => ({ sendPasswordResetEmail, sendVerificationEmail }))
+// Real bcrypt hashing is ~300ms a call and proves nothing here.
+vi.mock("bcryptjs", () => ({ default: { hash: vi.fn().mockResolvedValue("hashed") } }))
+vi.mock("@/lib/studio", () => ({ createStudioWithDefaults: vi.fn() }))
 
+import { AuthError } from "next-auth"
 import {
+  login,
+  createStudio,
   getMyStudioSlug,
   requestPasswordReset,
   resetPassword,
@@ -60,6 +69,105 @@ beforeEach(() => {
   vi.spyOn(console, "error").mockImplementation(() => {})
   sendPasswordResetEmail.mockResolvedValue({ success: true })
   sendVerificationEmail.mockResolvedValue({ success: true })
+})
+
+/** An AuthError as @auth/core delivers it: `type` plus the subclass's `code`. */
+function credentialsError(code: string) {
+  const err = new AuthError("sign-in failed") as AuthError & { type: string; code: string }
+  err.type = "CredentialsSignin"
+  err.code = code
+  return err
+}
+
+// Every one of these messages sent a real person round a loop they could not escape:
+// a studio-less account was told its password was wrong, so resetting the password
+// looked like the fix and never was.
+describe("login — what the user is told", () => {
+  it("says the account has no studio, rather than blaming the password", async () => {
+    signIn.mockRejectedValue(credentialsError("no_studio"))
+
+    const result = await login(form({ email: EMAIL, password: "correct-horse" }))
+
+    expect(result.error).toContain("no studio")
+    expect(result.error).not.toContain("Invalid email or password")
+  })
+
+  it("still says invalid credentials when the password really is wrong", async () => {
+    signIn.mockRejectedValue(credentialsError("invalid_credentials"))
+
+    const result = await login(form({ email: EMAIL, password: "wrong" }))
+
+    expect(result.error).toBe("Invalid email or password")
+  })
+
+  it("points an unverified account at its inbox", async () => {
+    signIn.mockRejectedValue(credentialsError("email_not_verified"))
+
+    const result = await login(form({ email: EMAIL, password: "correct-horse" }))
+
+    expect(result.error).toContain("verify your email")
+  })
+})
+
+describe("createStudio — what the user is told", () => {
+  const signup = () =>
+    form({
+      studioName: "Test Studio",
+      email: EMAIL,
+      password: "correct-horse",
+      confirmPassword: "correct-horse",
+      dpaAccepted: "true",
+    })
+
+  /** Runs the transaction callback against the mocked client, as Prisma would. */
+  function runTransaction() {
+    prisma.$transaction.mockImplementation((fn: (tx: unknown) => unknown) => fn(prisma))
+  }
+
+  it("never leaks a raw database error to the signup form", async () => {
+    // This exact message reached a user on the live site.
+    runTransaction()
+    prisma.user.findUnique.mockRejectedValue(
+      new Error(
+        "Invalid `prisma.studio.findUnique()` invocation: The column `(not available)` does not exist in the current database."
+      )
+    )
+
+    const result = await createStudio(signup())
+
+    expect(result.error).not.toContain("prisma")
+    expect(result.error).not.toContain("column")
+    expect(result.error).toBe("We couldn't create your studio right now. Please try again in a few minutes.")
+  })
+
+  it("does not claim a studio exists when the account owns none", async () => {
+    runTransaction()
+    prisma.user.findUnique.mockResolvedValue({ _count: { memberships: 0 } })
+
+    const result = await createStudio(signup())
+
+    expect(result.error).toContain("owns no studio")
+    expect(result.error).not.toContain("sign in to your existing studio")
+  })
+
+  it("points at the existing studio when the account really owns one", async () => {
+    runTransaction()
+    prisma.user.findUnique.mockResolvedValue({ _count: { memberships: 1 } })
+
+    const result = await createStudio(signup())
+
+    expect(result.error).toContain("already associated with a studio")
+  })
+
+  it("still surfaces a taken URL, which the user can act on", async () => {
+    runTransaction()
+    prisma.user.findUnique.mockResolvedValue(null)
+    prisma.studio.findUnique.mockResolvedValue({ id: "s1", slug: "test-studio" })
+
+    const result = await createStudio(signup())
+
+    expect(result.error).toContain("already taken")
+  })
 })
 
 // owner-login-form.tsx redirects on this after a successful sign-in. A null slug should


### PR DESCRIPTION
  Three messages sent a real person round an inescapable loop on the live
  site: a studio-less account was told its password was invalid, so
  resetting the password looked like the fix and never was; signup then
  refused the same email because it was "already associated with a studio"
  that did not exist; and when a query failed, the raw Prisma error was
  printed on the signup form.

  login(): map the no_studio code to a message naming the actual problem.
  invalid_credentials and email_not_verified are unchanged.

  createStudio(): count memberships on the existing-email check, so the
  "already associated with a studio" message is only used when one exists.

  createStudio(): the two errors the transaction throws on purpose are now
  StudioSignupError, and the catch surfaces only those. Anything else is
  logged server-side and shown as one plain sentence — it previously
  returned error.message for every Error, which is how
  "Invalid `prisma.studio.findUnique()` invocation" reached a user.