### PR TITLE
Send signed-in owners to their studio, not to a signup form

### DIFF
--- a/tattooista-next/src/components/platform-landing.tsx
+++ b/tattooista-next/src/components/platform-landing.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useRef, useCallback } from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useSession } from "next-auth/react"
 import {
   Dialog,
   DialogContent,
@@ -73,6 +75,30 @@ export function PlatformLanding() {
   const openRegister = useCallback(() => setDialogMode("register"), [])
   const closeDialog = useCallback(() => setDialogMode(null), [])
 
+  // Every session belongs to a studio owner, so none of the CTAs below should be
+  // offering them a signup form for a studio they already have.
+  const { data: session } = useSession()
+  const router = useRouter()
+  const studioSlug = session?.user?.studioSlug
+
+  // "Get Started", "Join Pilot", "Create Your Studio" — signing up is already done.
+  const startCta = useCallback(() => {
+    if (studioSlug) {
+      router.push(`/${studioSlug}/admin`)
+      return
+    }
+    openRegister()
+  }, [studioSlug, router, openRegister])
+
+  // "Go Pro" — the upgrade itself lives in the studio's billing settings.
+  const upgradeCta = useCallback(() => {
+    if (studioSlug) {
+      router.push(`/${studioSlug}/admin/settings`)
+      return
+    }
+    openRegister()
+  }, [studioSlug, router, openRegister])
+
   return (
     <div ref={revealRef}>
       <PlatformHeader onSignIn={openLogin} />
@@ -101,7 +127,7 @@ export function PlatformLanding() {
           <div className="flex flex-wrap gap-4 items-center mb-4 animate-[fadeUp_0.8s_ease-out_0.45s_both]">
             <button
               type="button"
-              onClick={openRegister}
+              onClick={startCta}
               className="inline-flex items-center justify-center px-12 h-[60px] bg-foreground text-background text-sm font-semibold tracking-[2px] uppercase border-2 border-foreground transition-all duration-300 hover:bg-transparent hover:text-foreground"
             >
               Get Early Access
@@ -206,7 +232,7 @@ export function PlatformLanding() {
               </ul>
               <button
                 type="button"
-                onClick={openRegister}
+                onClick={startCta}
                 className="self-start inline-flex items-center justify-center px-12 h-[60px] bg-foreground text-background text-sm font-semibold tracking-[2px] uppercase border-2 border-foreground transition-all duration-300 hover:bg-transparent hover:text-foreground"
               >
                 Create Your Studio
@@ -250,7 +276,7 @@ export function PlatformLanding() {
               </ul>
               <button
                 type="button"
-                onClick={openRegister}
+                onClick={startCta}
                 className="w-full inline-flex items-center justify-center h-[60px] border-2 border-foreground/25 text-[#c7c7c7] text-sm font-semibold tracking-[2px] uppercase transition-all duration-300 hover:border-foreground hover:text-foreground"
               >
                 Get Started
@@ -275,7 +301,7 @@ export function PlatformLanding() {
               </ul>
               <button
                 type="button"
-                onClick={openRegister}
+                onClick={upgradeCta}
                 className="w-full inline-flex items-center justify-center h-[60px] border-2 border-foreground/25 text-[#c7c7c7] text-sm font-semibold tracking-[2px] uppercase transition-all duration-300 hover:border-foreground hover:text-foreground"
               >
                 Go Pro
@@ -303,7 +329,7 @@ export function PlatformLanding() {
               </ul>
               <button
                 type="button"
-                onClick={openRegister}
+                onClick={upgradeCta}
                 className="w-full inline-flex items-center justify-center h-[60px] bg-foreground text-background text-sm font-semibold tracking-[2px] uppercase border-2 border-foreground transition-all duration-300 hover:bg-transparent hover:text-foreground"
               >
                 Go Pro Yearly
@@ -327,7 +353,7 @@ export function PlatformLanding() {
           </p>
           <button
             type="button"
-            onClick={openRegister}
+            onClick={startCta}
             className="landing-reveal inline-flex items-center justify-center px-12 h-[60px] bg-foreground text-background text-sm font-semibold tracking-[2px] uppercase border-2 border-foreground transition-all duration-300 hover:bg-transparent hover:text-foreground"
           >
             Join Pilot


### PR DESCRIPTION
  Every call to action on the landing page opened the "Create Your Studio"
  dialog unconditionally — the page never read the session. A signed-in
  owner clicking "Go Pro" on the pricing table was asked to sign up for a
  studio they already have, and the same went for Get Early Access, Create
  Your Studio, Get Started and Join Pilot.

  Route them by intent instead: the two Go Pro buttons go to the studio's
  billing settings, where the Paddle checkout lives; the rest go to the
  studio admin. Signed out, all six open the signup dialog as before, and
  "Create one" inside the login dialog is untouched — you cannot be signed
  in and reading it.

  Also add Log Out to the platform header, after My Studio, using the
  header's existing nav link styling and the same sign-out behaviour as
  the studio header.